### PR TITLE
Solve problem by forcing golang to use cgo resolver

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,3 +20,4 @@ alpine:
         - postgres
     environment:
         DB: "postgres://postgres@postgres/postgres?sslmode=disable"
+        GODEBUG: "netdns=cgo"


### PR DESCRIPTION
### The solution

The (or "A") solution to the problem is to force Go to use the `cgo` resolver.
This makes name resolution work as intended. For some reason, the golang:alpine resolution does not work correctly.


### Production vs Development Environments

As this issue does not present itself in any production environment, but only in my dev environment, I consider this a perfectly acceptable solution to the problem.


### Read more

See more about name resolution here: https://golang.org/pkg/net/#hdr-Name_Resolution