### PR TITLE
Prevent search-domain propagation to docker-compose containers

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,7 @@ postgres:
 #        - "5432"
 
 build:
+    dns_search: .
     image: mamarcus.org/project:build
     links:
         - postgres
@@ -15,6 +16,7 @@ build:
         DB: "postgres://postgres@postgres/postgres?sslmode=disable"
 
 alpine:
+    dns_search: .
     image: mamarcus.org/project:alpine
     links:
         - postgres


### PR DESCRIPTION
### The solution

To really resolve the issue, which was caused by a local network's search domain, each container is configured to not use any external search domains (or for the network not to have a search domain to start with). 

This can easily be configured in `docker-compose.yml`